### PR TITLE
Add limits.h include to provide INT_MAX.

### DIFF
--- a/tests/test_common_openssl.c
+++ b/tests/test_common_openssl.c
@@ -1,5 +1,6 @@
 #include "test_common.h"
 
+#include <limits.h>
 #include <openssl/opensslv.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>


### PR DESCRIPTION
This is required per POSIX: http://pubs.opengroup.org/onlinepubs/009604499/basedefs/limits.h.html

Otherwise test build is failing on OpenBSD:

```
libsignal-protocol-c/tests/test_common_openssl.c:218:24: error: use of undeclared identifier 'INT_MAX'
    if(plaintext_len > INT_MAX - EVP_CIPHER_block_size(evp_cipher)) {
                       ^
```