### PR TITLE
Introduce srand_deterministic to match OpenBSD

### DIFF
--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -845,3 +845,10 @@ void setup_test_sender_key_store(signal_protocol_store_context *context, signal_
 
     signal_protocol_store_context_set_sender_key_store(context, &store);
 }
+
+#ifndef __OpenBSD__
+void srand_deterministic(unsigned int seed) {
+    srand(seed);
+}
+#endif
+

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -84,4 +84,10 @@ int test_sender_key_store_load_sender_key(signal_buffer **record, signal_buffer 
 void test_sender_key_store_destroy(void *user_data);
 void setup_test_sender_key_store(signal_protocol_store_context *context, signal_context *global_context);
 
+/* Portability */
+#ifndef __OpenBSD__
+/* OpenBSD extension */
+void srand_deterministic(unsigned int seed);
+#endif
+
 #endif /* TEST_COMMON_H */

--- a/tests/test_session_builder.c
+++ b/tests/test_session_builder.c
@@ -1426,9 +1426,9 @@ void run_interaction(signal_protocol_store_context *alice_store, signal_protocol
     }
 
     time_t seed = time(0);
-    srand(seed);
+    srand_deterministic(seed);
     shuffle_buffers(alice_ooo_plaintext, 10);
-    srand(seed);
+    srand_deterministic(seed);
     shuffle_buffers(alice_ooo_ciphertext, 10);
     fprintf(stderr, "Shuffled Alice->Bob messages created\n");
 

--- a/tests/test_session_cipher.c
+++ b/tests/test_session_cipher.c
@@ -206,9 +206,9 @@ void generate_test_message_collections(session_cipher *cipher, signal_buffer **p
 
     /* Randomize the two arrays using the same seed */
     time_t seed = time(0);
-    srand(seed);
+    srand_deterministic(seed);
     shuffle_buffers(plaintext_messages, size);
-    srand(seed);
+    srand_deterministic(seed);
     shuffle_buffers(ciphertext_messages, size);
 }
 


### PR DESCRIPTION
Makes explicit deterministic seeding of PRNG obvious.

Fixes #119