### PR TITLE
pkg-config file updates: 'Libs: -lm' + no '/signal' in 'Cflags: -I'

### DIFF
--- a/src/libsignal-protocol-c.pc.in
+++ b/src/libsignal-protocol-c.pc.in
@@ -9,5 +9,5 @@ Description: Signal Protocol C Library
 Version: @SIGNAL_PROTOCOL_C_VERSION@
 
 Requires:
-Libs: -L${libdir} -L${sharedlibdir} -l@PROJECT_NAME@
-Cflags: -I${includedir}/signal
+Libs: -L${libdir} -L${sharedlibdir} -l@PROJECT_NAME@ -lm
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi,

when linking using the `pkg-config` file, `-lm` is missing. As far as I can see it is used only once:
https://github.com/signalapp/libsignal-protocol-c/blob/71954c53860b83e358c9d8c4898d003f16ace375/src/hkdf.c#L109 This patch adds `-lm` to the `pkg-config` file.

It also removes the trailing path component `/signal` for the `-I` option in `libsignal-protocol-c.pc.in`, as this leads to "namespace pollution" in the sense that every `pkg-config` user of this library cannot use the file names of any header file `libsignal-protocol-c` provides (which are quite many). Leaving the path prefixed by `signal/` on the client side is cleaner (and also what other libraries' `pkg-config` file exports, e.g., OpenSSL has its headers in `include/openssl/` but does not include the suffix in its `-I` option).

Thanks for your consideration.